### PR TITLE
Remove `rlib` crate-type so that it works with Miri

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,6 @@
-[lib]
-crate-type = ["rlib"]
-
 [package]
 name = "uninit"
-version = "0.4.0"
+version = "0.4.1-dev"
 authors = ["Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Having

```toml
[lib]
crate-type = ["rlib"]
```

breaks compilation with miri (cc @ralfjung, maybe that should be mentioned in the README.md).

  - <details><summary>repro</summary>

    ```bash
    cd $(mktemp -d)

    cargo init --lib --name foo

    cargo new --lib bar && cargo add --path bar{,}  # cargo-edit

    cat >>bar/Cargo.toml<<\#\ END
    [lib]
    crate-type = ["rlib"]
    # END

    echo 'use ::bar;' >> src/lib.rs

    cargo miri test
    ```

    </details>

Now, I cannot remember why I put that `"rlib"` thing to begin with, but after looking in more detail into what it does, I think it's doing do more harm than any potential good (or, at least, I should be using `["rlib", "lib"]` to avoid removing `"lib"` when with some compiler (such as miri's?) it isn't an alias for `"rlib"`. And until somebody observes some breakage from replacing `"rlib"` back with the default `"lib"`, I will be favoring the default setting).