### PR TITLE
Draft: unify `Out<[T]>` methods with `Sized` methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "uninit"
-version = "0.5.1-rc1"
+version = "0.6.0"
 dependencies = [
  "extension-traits",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uninit"
-version = "0.5.1"
-authors = ["Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"]
+version = "0.6.0"
+authors = ["Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>", "Alyssa Haroldsen <kupiakos@gmail.com>"]
 edition = "2018"
 
 documentation = "https://docs.rs/uninit"

--- a/src/extension_traits/as_out.rs
+++ b/src/extension_traits/as_out.rs
@@ -2,6 +2,8 @@ use_prelude!();
 
 use ::core::mem::ManuallyDrop;
 
+use crate::extension_traits::AsUninit;
+
 #[cfg(doc)]
 use crate::extension_traits::ManuallyDropMut;
 
@@ -40,7 +42,7 @@ use crate::extension_traits::ManuallyDropMut;
 /// assert_eq!(x, y);
 /// ```
 pub
-trait AsOut<Pointee : ?Sized> {
+trait AsOut<Pointee : ?Sized + AsUninit> {
     #[allow(missing_docs)]
     fn as_out<'out> (self: &'out mut Self)
       -> Out<'out, Pointee>

--- a/src/extension_traits/as_uninit.rs
+++ b/src/extension_traits/as_uninit.rs
@@ -1,0 +1,75 @@
+use super::MaybeUninitExt;
+
+use_prelude!();
+
+// Notes for the reviewer:
+// This is similar to `MaybeUninitExt` - should it be consolidated into this one?
+// Should this be in this module? It's used more as a marker/conversion trait than an extension trait.
+
+/// Converts a reference to its uninitialized form.
+pub unsafe trait AsUninit {
+    /// # Guarantees (that `unsafe` code may rely on)
+    /// 
+    /// This type must have the same layout as `Self` but with no requirement on its contents.
+    type Uninit: ?Sized + MaybeUninitExt<T = Self>;
+
+    /// Converts a `&self` to its uninitialized equivalent.
+    /// 
+    /// # Guarantees (that `unsafe` code may rely on)
+    /// 
+    /// - The input and output address match.
+    fn as_ref_uninit(&self) -> &Self::Uninit;
+
+    /// Converts a `&mut T` to its uninitialized equivalent.
+    ///
+    /// This _upgrades_ the `&mut T` (read-write-valid-values-only) reference to a
+    /// `&mut MaybeUninit<_>` (write-anything) reference.
+    /// 
+    /// # Safety (for callers)
+    ///
+    /// The same requirements as [`Out::as_uninit_mut`].
+    /// Care should be taken with usage of the output - uninitialized garbage must not be written.
+    /// 
+    /// # Guarantees (that `unsafe` code may rely on)
+    /// 
+    /// - The input and output address match.
+    unsafe fn as_mut_uninit(&mut self) -> &mut Self::Uninit;
+}
+
+unsafe impl<T> AsUninit for T {
+    type Uninit = MaybeUninit<T>;
+
+    fn as_ref_uninit(&self) -> &Self::Uninit {
+        unsafe { &*(self as *const T).cast() }
+    }
+
+    unsafe fn as_mut_uninit(&mut self) -> &mut Self::Uninit {
+        &mut *(self as *mut T).cast()
+    }
+}
+
+// // Unfortunately this cannot `impl<T: ?Sized> AsUninit for ManuallyDrop<T>` as
+// // that would conflict with the `Sized` blanket impl.
+// unsafe impl<T> AsUninit for ManuallyDrop<[T]> {
+//     type Uninit = [MaybeUninit<ManuallyDrop<T>>];
+
+//     fn as_ref_uninit(&self) -> &Self::Uninit {
+//         todo!()
+//     }
+
+//     unsafe fn as_mut_uninit(&mut self) -> &mut Self::Uninit {
+//         todo!()
+//     }
+// }
+
+unsafe impl<T> AsUninit for [T] {
+    type Uninit = [MaybeUninit<T>];
+
+    fn as_ref_uninit(&self) -> &Self::Uninit {
+        unsafe { &*(self as *const [T] as *const [MaybeUninit<T>]) }
+    }
+
+    unsafe fn as_mut_uninit(&mut self) -> &mut Self::Uninit {
+        &mut *(self as *mut [T] as *mut [MaybeUninit<T>])
+    }
+}

--- a/src/extension_traits/mod.rs
+++ b/src/extension_traits/mod.rs
@@ -4,6 +4,10 @@ pub use self::as_out::{
     AsOut,
 };
 mod as_out;
+pub use self::as_uninit::{
+    AsUninit,
+};
+mod as_uninit;
 
 pub use self::manually_drop_mut::{
     ManuallyDropMut,

--- a/src/extension_traits/vec.rs
+++ b/src/extension_traits/vec.rs
@@ -170,7 +170,7 @@ impl<T> VecCapacity for Vec<T> {
             unsafe {
                 // Safety: the first `len` elements are initialized (safety
                 // invariant of `Vec<T>`).
-                slice::from_raw_parts_mut(xs.as_mut_ptr(), len)
+                &mut *xs.as_mut_ptr()
             },
             unsafe {
                 // Safety: that part is indeed uninit and garbage can be written

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -145,7 +145,7 @@ trait ReadIntoUninit : Read {
             //
             //   - this is the "concatenation" of all the "buf[.. n]"
             //     initialisation witnesses.
-            buf.assume_all_init()
+            buf.assume_init()
         })
     }
 


### PR DESCRIPTION
This unifies much of the `Out<T: Sized>` and `Out<[T]>` methods through a new trait, `AsUninit`.

Better tests, safety docs, and general doc/example adjustments will be needed before this is finalized.